### PR TITLE
create more detailed release body and name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 16
+    - name: Set up JDK 17
       uses: actions/setup-java@v1
       with:
-        java-version: 16
+        java-version: 17
     - name: Set env
       run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
     - name: Set up keystore
@@ -30,31 +30,32 @@ jobs:
       run: |
         git clone --depth=1 --branch=master https://github.com/Anuken/Mindustry
         cd Mindustry
-        echo "BODY=$(git rev-parse HEAD)" >> $GITHUB_ENV
+        echo "BODY=$(git log -1 --pretty=format:'%B%nCommit Hash: `%H`')" >> $GITHUB_ENV
         sed -i 's/applicationId "io.anuke.mindustry"/applicationId "io.anuke.mindustry.be"/g' android/build.gradle
         sed -i 's/"io.anuke.mindustry"/"io.anuke.mindustry.be"/g' android/AndroidManifest.xml
         sed -i 's/Mindustry/Mindustry BE/g' android/res/values/strings.xml
         ./gradlew pack
         ./gradlew desktop:dist server:dist android:assembleRelease -Pbuildversion=${RELEASE_VERSION} -PversionType=bleeding-edge --stacktrace
-        mv desktop/build/libs/Mindustry.jar desktop/build/libs/Mindustry-BE-Desktop-${RELEASE_VERSION}.jar
-        mv server/build/libs/server-release.jar server/build/libs/Mindustry-BE-Server-${RELEASE_VERSION}.jar
-        mv android/build/outputs/apk/release/android-release.apk android/build/outputs/apk/release/Mindustry-BE-Android-${RELEASE_VERSION}.apk
     - name: Upload desktop artifacts
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: Mindustry/desktop/build/libs/Mindustry-BE-Desktop-${{ env.RELEASE_VERSION }}.jar
+        file: Mindustry/desktop/build/libs/Mindustry.jar
         tag: ${{ github.ref }}
+        asset_name: Mindustry-BE-Desktop-${{ env.RELEASE_VERSION }}.jar
+        release_name: "Build #${{ env.RELEASE_VERSION }}"
         body: ${{ env.BODY }}
     - name: Upload server artifacts
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: Mindustry/server/build/libs/Mindustry-BE-Server-${{ env.RELEASE_VERSION }}.jar
+        file: Mindustry/server/build/libs/server-release.jar
         tag: ${{ github.ref }}
+        asset_name: Mindustry-BE-Server-${{ env.RELEASE_VERSION }}.jar
     - name: Upload Android artifacts
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: Mindustry/android/build/outputs/apk/release/Mindustry-BE-Android-${{ env.RELEASE_VERSION }}.apk
+        file: Mindustry/android/build/outputs/apk/release/android-release.apk
         tag: ${{ github.ref }}
+        asset_name: Mindustry-BE-Android-${{ env.RELEASE_VERSION }}.apk


### PR DESCRIPTION
also use java 17 instead of 16
minor refractor to use `asset_name`

release name is now smth like:
> Build #25019

body is now smth like:
> Request a GL 3 context by default
>
> Commit Hash: `bd610b6925f265c50244c5852051c70ce04f1d6f`